### PR TITLE
Fix typo in metadata definition

### DIFF
--- a/lib/utils/metadata.js
+++ b/lib/utils/metadata.js
@@ -54,7 +54,7 @@ module.exports = {
       }
    },
    "pathAssistants":{
-      "xmlName":"PathAssistants",
+      "xmlName":"PathAssistant",
       "children":{  
 
       }


### PR DESCRIPTION
@scolladon I'm very sorry. I made a typo in the metadata.js. It's "PathAssistant" (without the 's' at the end). Again, I'm extremely sorry for this...  Thanks again, regards. 
Leo